### PR TITLE
Update libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ Carthage
 # `pod install` in .travis.yml
 #
 # Pods/
-Podfile.lock
+

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -8,6 +8,6 @@ end
 target 'SwiftECP_Tests', :exclusive => true do
   pod "SwiftECP", :path => "../"
 
-  pod 'Quick', '~> 0.6.0'
-  pod 'Nimble', '2.0.0-rc.3'
+  pod 'Quick', '~> 0.9.1'
+  pod 'Nimble', '3.1.0'
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,0 +1,44 @@
+PODS:
+  - AEXML (2.1.0)
+  - Alamofire (3.0.1)
+  - Nimble (3.1.0)
+  - Quick (0.9.1)
+  - ReactiveCocoa (4.0.4-alpha-4):
+    - ReactiveCocoa/UI (= 4.0.4-alpha-4)
+    - Result (~> 1.0)
+  - ReactiveCocoa/Core (4.0.4-alpha-4):
+    - ReactiveCocoa/no-arc
+    - Result (~> 1.0)
+  - ReactiveCocoa/no-arc (4.0.4-alpha-4):
+    - Result (~> 1.0)
+  - ReactiveCocoa/UI (4.0.4-alpha-4):
+    - ReactiveCocoa/Core
+    - Result (~> 1.0)
+  - Result (1.0.2)
+  - SwiftECP (2.0.2):
+    - AEXML (~> 2.0)
+    - Alamofire (~> 3.0.0-beta.3)
+    - ReactiveCocoa (= 4.0.4-alpha-4)
+    - XCGLogger (~> 3.0)
+  - XCGLogger (3.2)
+
+DEPENDENCIES:
+  - Nimble (= 3.1.0)
+  - Quick (~> 0.9.1)
+  - SwiftECP (from `../`)
+
+EXTERNAL SOURCES:
+  SwiftECP:
+    :path: "../"
+
+SPEC CHECKSUMS:
+  AEXML: 0e2f657fdc67e17905682a06d55583a863d80803
+  Alamofire: 2457e1b2e6c46bb05c3a598c542b7bfd08893775
+  Nimble: 79d40f4d69d47314229bbabacaa02b8838c779b9
+  Quick: a5221fc21788b6aeda934805e68b061839bc3165
+  ReactiveCocoa: e459ea92099447802df20c4735e31e8139b06094
+  Result: dd3dd71af3fa2e262f1a999e14fba2c25ec14f16
+  SwiftECP: cdb401698fdae671b29540030fa26f83430945b4
+  XCGLogger: da1f341f4bb8979db6e1df64232f04d9698402d4
+
+COCOAPODS: 0.39.0

--- a/Example/SwiftECP.xcodeproj/project.pbxproj
+++ b/Example/SwiftECP.xcodeproj/project.pbxproj
@@ -7,14 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0EAD66C463068797AE0C6200 /* Pods_SwiftECP_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98BD321E4BD4ED26F868ACE8 /* Pods_SwiftECP_Tests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		0EAD66C463068797AE0C6200 /* Pods_SwiftECP_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98BD321E4BD4ED26F868ACE8 /* Pods_SwiftECP_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
-		654E97E369FCF1C5D518564F /* Pods_SwiftECP_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C33543E2266143E823B25B1E /* Pods_SwiftECP_Example.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		654E97E369FCF1C5D518564F /* Pods_SwiftECP_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C33543E2266143E823B25B1E /* Pods_SwiftECP_Example.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */

--- a/Example/SwiftECP/ViewController.swift
+++ b/Example/SwiftECP/ViewController.swift
@@ -32,7 +32,7 @@ class ViewController: UIViewController {
                     print(shibCookie)
                 }
 
-            case let .Error(error):
+            case let .Failed(error):
                 // This is an NSError containing both a user-friendly message and a
                 // technical debug message. This can help diagnose problems with your
                 // SP, your IdP, or even this library :)

--- a/Pod/Classes/Alamofire+ReactiveCocoa.swift
+++ b/Pod/Classes/Alamofire+ReactiveCocoa.swift
@@ -55,52 +55,50 @@ extension Alamofire.Request {
 
     public func responseXML() -> SignalProducer<CheckedResponse<AEXMLDocument>, NSError> {
         return SignalProducer { observer, disposable in
-            responseXML { response in
+            self.responseXML { response in
                 if let error = response.result.error {
-                    return sendError(observer, error)
+                    return observer.sendFailed(error)
                 }
 
                 guard let document = response.result.value else {
-                    return sendError(observer, AlamofireRACError.XMLSerialization as NSError)
+                    return observer.sendFailed(AlamofireRACError.XMLSerialization as NSError)
                 }
 
                 guard let request = response.request, response = response.response else {
-                    return sendError(observer, AlamofireRACError.IncompleteResponse as NSError)
+                    return observer.sendFailed(AlamofireRACError.IncompleteResponse as NSError)
                 }
 
-                sendNext(
-                    observer,
+                observer.sendNext(
                     CheckedResponse<AEXMLDocument>(
                         request: request, response: response, value: document
                     )
                 )
-                sendCompleted(observer)
+                observer.sendCompleted()
             }
         }
     }
 
     public func responseString(errorOnNil: Bool = true) -> SignalProducer<CheckedResponse<String>, NSError> {
         return SignalProducer { observer, disposable in
-            responseStringEmptyAllowed { response in
+            self.responseStringEmptyAllowed { response in
                 if let error = response.result.error {
-                    return sendError(observer, error)
+                    return observer.sendFailed(error)
                 }
 
                 if errorOnNil && response.result.value?.characters.count == 0 {
-                    return sendError(observer, AlamofireRACError.XMLSerialization as NSError)
+                    return observer.sendFailed(AlamofireRACError.XMLSerialization as NSError)
                 }
 
                 guard let req = response.request, resp = response.response else {
-                    return sendError(observer, AlamofireRACError.IncompleteResponse as NSError)
+                    return observer.sendFailed(AlamofireRACError.IncompleteResponse as NSError)
                 }
 
-                sendNext(
-                    observer,
+                observer.sendNext(
                     CheckedResponse<String>(
                         request: req, response: resp, value: response.result.value ?? ""
                     )
                 )
-                sendCompleted(observer)
+                observer.sendCompleted()
             }
         }
     }

--- a/Pod/Classes/ECP.swift
+++ b/Pod/Classes/ECP.swift
@@ -60,16 +60,16 @@ public struct ECP {
                 req.responseXML().map { ($0, idpRequestData) }.start { event in
                     switch event {
                     case .Next(let value):
-                        sendNext(observer, value)
-                        sendCompleted(observer)
-                    case .Error(let error):
-                        sendError(observer, error)
+                        observer.sendNext(value)
+                        observer.sendCompleted()
+                    case .Failed(let error):
+                        observer.sendFailed(error)
                     default:
                         break
                     }
                 }
             } catch {
-                sendError(observer, error as NSError)
+                observer.sendFailed(error as NSError)
             }
         }
     }
@@ -89,16 +89,16 @@ public struct ECP {
                 req.responseString(false).map { $0.value }.start { event in
                     switch event {
                     case .Next(let value):
-                        sendNext(observer, value)
-                        sendCompleted(observer)
-                    case .Error(let error):
-                        sendError(observer, error)
+                        observer.sendNext(value)
+                        observer.sendCompleted()
+                    case .Failed(let error):
+                        observer.sendFailed(error)
                     default:
                         break
                     }
                 }
             } catch {
-                sendError(observer, error as NSError)
+                observer.sendFailed(error as NSError)
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ECP(
             print(shibCookie)
         }
 
-    case let .Error(error):
+    case let .Failed(error):
         // This is an NSError containing both a user-friendly message and a
         // technical debug message. This can help diagnose problems with your
         // SP, your IdP, or even this library :)

--- a/SwiftECP.podspec
+++ b/SwiftECP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SwiftECP"
-  s.version          = "2.0.1"
+  s.version          = "2.0.2"
   s.summary          = "SwiftECP is a simple Shibboleth ECP client for iOS."
   s.description      = <<-DESC
                        Need Shibboleth login on your iOS app but don't want to use a webview? Don't want to deal with XML or read a spec? Use SwiftECP to do the work for you! SwiftECP is a spec-conformant Shibboleth ECP client for iOS. Simply provide credentials and a Shibboleth-protected resource URL and SwiftECP will hand you a Shibboleth cookie to attach to further requests or inject into a webview.
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'AEXML', '~> 2.0'
   s.dependency 'Alamofire', '~> 3.0.0-beta.3'
-  s.dependency 'ReactiveCocoa', '4.0.2-alpha-1'
+  s.dependency 'ReactiveCocoa', '4.0.4-alpha-4'
   s.dependency 'XCGLogger', '~> 3.0'
 end


### PR DESCRIPTION
Update to latest versions ReactiveCocoa, Quick, and Nimble pods to fix `Include of non-modular header inside framework module ...` build errors when using cocoapods 0.39.0.

Track [Podfile.lock](https://guides.cocoapods.org/using/using-cocoapods.html#what-is-podfilelock) so that future `pod install`s will get a known good configuration.
